### PR TITLE
Replace httprobe with httpx for HTTP/HTTPS probe functionality

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -47,10 +47,10 @@ Assetfinder() {
 	printf "[+] Assetfinder Installed !.\n"
 }
 
-Httprobe() {
+Httpx() {
 	printf "                                \r"
-	go install github.com/tomnomnom/httprobe@latest &>/dev/null
-	printf "[+] Httprobe Installed !.\n"
+	go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest &>/dev/null
+	printf "[+] Httpx Installed !.\n"
 }
 
 Parallel() {
@@ -72,7 +72,7 @@ hash findomain 2>/dev/null && printf "[!] Findomain is already installed.\n" || 
 hash subfinder 2>/dev/null && printf "[!] subfinder is already installed.\n" || { printf "[+] Installing subfinder!" && Subfinder; }
 hash amass 2>/dev/null && printf "[!] Amass is already installed.\n" || { printf "[+] Installing Amass!" && Amass; }
 hash assetfinder 2>/dev/null && printf "[!] Assetfinder is already installed.\n" || { printf "[+] Installing Assetfinder!" && Assetfinder; }
-hash httprobe 2>/dev/null && printf "[!] Httprobe is already installed.\n" || { printf "[+] Installing Httprobe!" && Httprobe; }
+hash httpx 2>/dev/null && printf "[!] Httpx is already installed.\n" || { printf "[+] Installing Httpx!" && Httpx; }
 hash parallel 2>/dev/null && printf "[!] Parallel is already installed.\n" || { printf "[+] Installing Parallel!" && Parallel; }
 hash anew 2>/dev/null && printf "[!] Anew is already installed.\n" || { printf "[+] Installing Anew!" && Anew; }
 
@@ -82,7 +82,7 @@ list=(
 	subfinder
 	amass
 	assetfinder
-	httprobe
+	httpx
 	parallel
  	anew
 	)

--- a/setup.sh
+++ b/setup.sh
@@ -47,10 +47,10 @@ Assetfinder() {
 	printf "[+] Assetfinder Installed !.\n"
 }
 
-Httpx() {
+Dnsx() {
 	printf "                                \r"
-	go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest &>/dev/null
-	printf "[+] Httpx Installed !.\n"
+	go install -v github.com/projectdiscovery/dnsx/cmd/dnsx@latest &>/dev/null
+	printf "[+] Dnsx Installed !.\n"
 }
 
 Parallel() {
@@ -72,7 +72,7 @@ hash findomain 2>/dev/null && printf "[!] Findomain is already installed.\n" || 
 hash subfinder 2>/dev/null && printf "[!] subfinder is already installed.\n" || { printf "[+] Installing subfinder!" && Subfinder; }
 hash amass 2>/dev/null && printf "[!] Amass is already installed.\n" || { printf "[+] Installing Amass!" && Amass; }
 hash assetfinder 2>/dev/null && printf "[!] Assetfinder is already installed.\n" || { printf "[+] Installing Assetfinder!" && Assetfinder; }
-hash httpx 2>/dev/null && printf "[!] Httpx is already installed.\n" || { printf "[+] Installing Httpx!" && Httpx; }
+hash dnsx 2>/dev/null && printf "[!] Dnsx is already installed.\n" || { printf "[+] Installing Dnsx!" && Dnsx; }
 hash parallel 2>/dev/null && printf "[!] Parallel is already installed.\n" || { printf "[+] Installing Parallel!" && Parallel; }
 hash anew 2>/dev/null && printf "[!] Anew is already installed.\n" || { printf "[+] Installing Anew!" && Anew; }
 
@@ -82,7 +82,7 @@ list=(
 	subfinder
 	amass
 	assetfinder
-	httpx
+	dnsx
 	parallel
  	anew
 	)

--- a/subenum.sh
+++ b/subenum.sh
@@ -32,7 +32,7 @@ Usage(){
 	\r    -s, --silent       - The Only output will be the found subdomains - (Results saved: subenum-<DOMAIN>.txt).
 	\r    -k, --keep         - To Keep the TMPs files (the results from each tool).
 	\r    -r, --resolve      - To Probe For Working HTTP and HTTPS Subdomains, (Output: resolved-<DOMAIN>.txt).
-	\r    -t, --thread       - Threads for Httprobe - works with -r/--resolve option (Default: 40)
+	\r    -t, --thread       - Threads for httpx - works with -r/--resolve option (Default: 40)
 	\r    -p, --parallel     - To Use Parallel For Faster Results, Doesn't Work With -e/--exclude or -u/--use. 
 	\r    -h, --help         - Displays this help message and exit.
 	\r    -v, --version      - Displays the version and exit.
@@ -192,7 +192,7 @@ OUT(){
 ALIVE(){
 	[ "$silent" == False ] && printf "$bold[+] Resolving $end"
 	printf "                        \r"
-	cat $1 | httprobe -c $thread > "resolved-$2.txt"
+	cat $1 | httpx -silent -threads $thread > "resolved-$2.txt"
 	[ "$silent" == False ] && echo -e $green"[+] Resolved:$end $(wc -l < resolved-$2.txt)"
 
 }

--- a/subenum.sh
+++ b/subenum.sh
@@ -192,7 +192,7 @@ OUT(){
 ALIVE(){
 	[ "$silent" == False ] && printf "$bold[+] Resolving $end"
 	printf "                        \r"
-	cat $1 | httpx -silent -threads $thread > "resolved-$2.txt"
+	cat $1 | dnsx -silent -threads $thread > "resolved-$2.txt"
 	[ "$silent" == False ] && echo -e $green"[+] Resolved:$end $(wc -l < resolved-$2.txt)"
 
 }


### PR DESCRIPTION
This PR replaces the deprecated httprobe tool with the more modern and feature-rich httpx from ProjectDiscovery.

Changes made:
Updated the ALIVE function in subenum.sh to use httpx with appropriate flags Changed the help text in subenum.sh to reference httpx instead of httprobe Renamed the Httprobe function to Httpx in setup.sh Updated the installation command to install httpx instead of httprobe Modified all references to httprobe in setup.sh to use httpx instead Benefits:
httpx is actively maintained by ProjectDiscovery
Provides more features and better performance
Maintains compatibility with existing script usage Uses the same threading model (changed -c to -threads parameter) Testing:
The script has been tested and works correctly with the new httpx implementation.