### PR TITLE
Removing the  -noalts Flag from Amass Command

### DIFF
--- a/subenum.sh
+++ b/subenum.sh
@@ -135,7 +135,7 @@ Subfinder() {
 
 Amass() {
 	# amass is with "-passive" option to make it faster, but it may cuz less results
-	[ "$silent" == True ] && amass enum -passive -norecursive -noalts -d $domain 2>/dev/null | anew subenum-$domain.txt || {
+	[ "$silent" == True ] && amass enum -passive -norecursive -d $domain 2>/dev/null | anew subenum-$domain.txt || {
 		[[ ${PARALLEL} == True ]] || { spinner "${bold}Amass${end}" &
 			PID="$!"
 		}


### PR DESCRIPTION
Removing the **-noalts** Flag from Amass Command.
In the latest version of the Amass script, the -noalts flag has been removed. Including this flag would prevent the Amass command from running and result in an error. Now, by removing this flag from the SubEnum, the command works correctly.

Amass User Guide :
https://github.com/owasp-amass/amass/blob/master/doc/user_guide.md